### PR TITLE
Update to Version 1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.0] - 2024-06-03
+
+* Update library name to be consistent with other Sensirion library names.
+
 ## [1.0.0] - 2023-03-14
 
 Initial release

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Sensirion UART SFx6xxx
-version=1.0.0
+version=1.1.0
 author=Sensirion
 maintainer=Sensirion
 sentence=Library for the SFX6XXX sensor family by Sensirion


### PR DESCRIPTION
Bump version for a release with update library name so we can request library name change on the Arduino library registry.

See: https://github.com/arduino/library-registry/issues/4576